### PR TITLE
ask permission popup fix, callback execution and tests -no androidx branch

### DIFF
--- a/android_notify/internal/helper.py
+++ b/android_notify/internal/helper.py
@@ -40,14 +40,16 @@ def get_package_path():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def execute_callback(callback,arg):
+def execute_callback(callback,arg, from_who="user"):
     """
     Executing Callbacks Safely
     """
-    if callback:
+    if not callback:
         return None
+    if from_who == "user":
+        logger.info(f"Executing On Permission Result Callback...")
     try:
-        if can_accept_arguments(callback, True):
+        if can_accept_arguments(callback, arg):
             callback(arg)
         else:
             callback()

--- a/android_notify/tests/main.py
+++ b/android_notify/tests/main.py
@@ -29,6 +29,7 @@ from android_notify.tests.test_notification_behavior import TestNotificationBeha
 from android_notify.tests.test_notification_progress import TestNotificationProgress
 from android_notify.tests.test_notification_sound import TestNotificationSound
 from android_notify.tests.test_notification_clear import TestClearNotifications
+from android_notify.tests.test_notification_permission import NOTIFICATION_PERMISSION_TESTS
 from kivy.clock import Clock
 
 # -----------------------------
@@ -82,6 +83,7 @@ class TripleClickButton(Button):
 class AndroidNotifyDemoApp(MDApp):
 
     def on_start(self):
+        print('starting app...')
         try:
             from kivymd.toast import toast
             name = NotificationHandler.get_name(on_start=True)
@@ -89,6 +91,7 @@ class AndroidNotifyDemoApp(MDApp):
         except Exception as e:
             print("Error getting notify name:", e)
 
+        print('on_start','-'*33)
 
         def android_service():
 
@@ -154,11 +157,28 @@ class AndroidNotifyDemoApp(MDApp):
             self.test_buttons.append(btn)
             main.add_widget(btn)
 
+        # Permission request needs human inputs for tests
+        for label, action in NOTIFICATION_PERMISSION_TESTS.items():
+            btn = self._btn(
+                f"Run: {label}",
+                lambda _, fn=action: self.run_action(fn, _)
+            )
+            main.add_widget(btn)
         return root
 
-    # -----------------------------
-    # Helper to make buttons
-    # -----------------------------
+    def run_action(self, action_fn, btn_instance):
+        btn_instance.disabled = True
+        print(f"\n▶ Running action: {action_fn.__name__}")
+
+        try:
+            action_fn()
+        except Exception as error_running_action:
+            print("error_running_action:", error_running_action)
+            traceback.print_exc()
+        finally:
+            # Re-enable AFTER user interaction finishes
+            btn_instance.disabled = False
+
     def _btn(self, text, callback, height=80):
         return TripleClickButton(
             text=text,
@@ -185,9 +205,6 @@ class AndroidNotifyDemoApp(MDApp):
             for btn in self.test_buttons:
                 btn.disabled = False
 
-    # -----------------------------
-    # Actions
-    # -----------------------------
     def request_permission(self, btn_instance):
         asks_permission_if_needed()
         btn_instance.disabled = False
@@ -204,16 +221,17 @@ class AndroidNotifyDemoApp(MDApp):
         btn_instance.disabled = False
 
     def on_resume(self):
+        print('resuming app..')
         try:
             from kivymd.toast import toast
             name = NotificationHandler.get_name()
-            toast(text=f"name: {name}", length_long=True)
+
+            toast(text=f"name: {name}, Permission:{NotificationHandler.has_permission()}", length_long=True)
         except Exception as e:
             print("Error getting notify name:", e)
+        print('on_resume','-'*33)
 
 
-# -----------------------------
-# Entry
-# -----------------------------
+
 if __name__ == "__main__":
     AndroidNotifyDemoApp().run()

--- a/android_notify/tests/test_notification_permission.py
+++ b/android_notify/tests/test_notification_permission.py
@@ -1,0 +1,38 @@
+# android_notify/tests/basic_notification_actions.py
+
+from android_notify import NotificationHandler
+from android_notify.internal.permissions import ask_notification_permission
+from android_notify.core import asks_permission_if_needed
+
+
+def ask_permission_no_callback():
+    NotificationHandler.asks_permission()
+
+
+def ask_permission_with_callback():
+    def some_callback(answer):
+        print(f"Hey Dude, Notification Request result {answer}.")
+    NotificationHandler.asks_permission(some_callback)
+
+
+def ask_permission_simple_regular():
+    asks_permission_if_needed()
+
+
+def ask_permission_simple_legacy():
+    asks_permission_if_needed(legacy=True)
+
+
+def ask_permission_from_source():
+    def some_callback(answer):
+        print(f"Hey, Notification Request Request1: {answer}")
+    ask_notification_permission(callback=some_callback)
+
+
+NOTIFICATION_PERMISSION_TESTS = {
+    "permission (no callback)": ask_permission_no_callback,
+    "permission (with callback)": ask_permission_with_callback,
+    "permission (simple)": ask_permission_simple_regular,
+    "permission (legacy)": ask_permission_simple_legacy,
+    "permission (from source)": ask_permission_from_source,
+}

--- a/android_notify/widgets/images.py
+++ b/android_notify/widgets/images.py
@@ -75,8 +75,6 @@ def icon_finder(icon_name):
         # noinspection PyPackageRequirements
         from importlib.resources import files
         return str(files("android_notify")/"fallback-icons"/icon_name)
-        # import pkg_resources
-        # return pkg_resources.resource_filename(__name__, f"fallback-icons/{icon_name}")
     except Exception:
         # Fallback if pkg_resources not available
         package_dir = get_package_path()


### PR DESCRIPTION
`shouldShowRequestPermissionRationale` acting weird now dependable when permission has been asked before.
- This patch uses an empty file to check asked state if first or not.
- This patch fixed not calling permission callback.
- Also added a way to get permission state when change from settings

Samples for different use cases
```python
from android_notify import NotificationHandler
from android_notify.internal.permissions import ask_notification_permission
from android_notify.core import asks_permission_if_needed


def ask_permission_no_callback():
    NotificationHandler.asks_permission()


def ask_permission_with_callback():
    def some_callback(answer):
        print(f"Hey Dude, Notification Request result {answer}.")
    NotificationHandler.asks_permission(some_callback)


def ask_permission_simple_regular():
    asks_permission_if_needed()


def ask_permission_simple_legacy():
    asks_permission_if_needed(legacy=True)


def ask_permission_from_source():
    def some_callback(answer):
        print(f"Hey, Notification Request Request1: {answer}")
    ask_notification_permission(callback=some_callback)


NOTIFICATION_PERMISSION_TESTS = {
    "permission (no callback)": ask_permission_no_callback,
    "permission (with callback)": ask_permission_with_callback,
    "permission (simple)": ask_permission_simple_regular,
    "permission (legacy)": ask_permission_simple_legacy,
    "permission (from source)": ask_permission_from_source,
}
```


When permission changed from setting, `on_resume` can be used, when app resumes to check permission if true then contuine to next screen

```python

class WallpaperCarouselApp(MDApp):

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.screen_manager = None

    def build(self):
        # set self.screen_manager
        pass

    def on_resume(self):
        if NotificationHandler.has_permission() and self.screen_manager:
            self.screen_managercurrent = "thumbs"
```


passed scoped tests [android_notify/tests/test_notification_permission.py](/Fector101/android_notify/blob/main/android_notify/tests/test_notification_permission.py)