### PR TITLE
making logs show On Flet Apps

### DIFF
--- a/android_notify/internal/logger.py
+++ b/android_notify/internal/logger.py
@@ -1,14 +1,51 @@
 import logging
 import sys
 import os
+import traceback
+
+try:
+    from jnius import autoclass
+except ModuleNotFoundError:
+    autoclass = lambda x: None
+
+
+def on_kivy_android():
+    kivy_build = os.environ.get('KIVY_BUILD', '')
+    if kivy_build in {'android'}:
+        return True
+    elif 'P4A_BOOTSTRAP' in os.environ:
+        return True
+    elif 'ANDROID_ARGUMENT' in os.environ:
+        return True
+
+    return False
+
+
+def on_flet_app():
+    return os.getenv("MAIN_ACTIVITY_HOST_CLASS_NAME")
+
+
+def on_android_platform():
+    return on_kivy_android() or on_flet_app()
+
+
+def android_print(msg):
+    msg = str(msg)
+    if on_android_platform():
+        Log = autoclass("android.util.Log")
+        Log.i("python", msg)
+        return None
+    print(msg)
+    return None
+
 
 class KivyColorFormatter(logging.Formatter):
     COLORS = {
-        'DEBUG': '\x1b[1;36m',    # bold cyan
-        'INFO': '\x1b[1;92m',     # bold lime green
+        'DEBUG': '\x1b[1;36m',  # bold cyan
+        'INFO': '\x1b[1;92m',  # bold lime green
         'WARNING': '\x1b[1;93m',  # bold yellow
-        'ERROR': '\x1b[1;91m',    # bold red
-        'CRITICAL': '\x1b[1;95m', # bold magenta
+        'ERROR': '\x1b[1;91m',  # bold red
+        'CRITICAL': '\x1b[1;95m',  # bold magenta
     }
     RESET = '\x1b[0m'
 
@@ -24,11 +61,88 @@ class KivyColorFormatter(logging.Formatter):
         return f"[{level}] [{name}] {msg}"
 
 
-logger = logging.getLogger("android_notify")
-# logger.setLevel(logging.NOTSET) # this override app logger level
+class AndroidNotifyLogger:
+    """
+    Patch logger for Android (Flet) where stdout logs don't always show.
+    Uses android.util.Log directly.
+    """
 
-handler = logging.StreamHandler(sys.stdout)
+    TAG = "python"
+
+    LEVELS = {
+        "debug": 10,
+        "info": 20,
+        "warning": 30,
+        "error": 40,
+        "critical": 50,
+    }
+
+    def __init__(self, level="debug"):
+        self.Log = autoclass("android.util.Log")
+        self.level = self.LEVELS[level]
+
+    def setLevel(self, level):
+        if isinstance(level, str):
+            level = level.lower()
+            if level not in self.LEVELS:
+                raise ValueError(f"Invalid log level: {level}")
+            self.level = self.LEVELS[level]
+        else:
+            self.Log.e(self.TAG, "Dude No such Level")
+            # raise TypeError("Log level must be a string")
+
+    def _log(self, level, msg):
+        if self.LEVELS[level] < self.level:
+            return
+
+        msg = str(msg)
+
+        if level == "debug":
+            self.Log.d(self.TAG, msg)
+        elif level == "info":
+            self.Log.i(self.TAG, msg)
+        elif level == "warning":
+            self.Log.w(self.TAG, msg)
+        elif level == "error":
+            self.Log.e(self.TAG, msg)
+        elif level == "critical":
+            self.Log.wtf(self.TAG, msg)
+
+    def debug(self, msg):
+        self._log("debug", msg)
+
+    def info(self, msg):
+        self._log("info", msg)
+
+    def warning(self, msg):
+        self._log("warning", msg)
+
+    def error(self, msg):
+        self._log("error", msg)
+
+    def critical(self, msg):
+        self._log("critical", msg)
+
+    def exception(self, msg):
+        self._log("error", msg)
+        self._log("error", traceback.format_exc())
+
+    def addHandler(self, _):
+        # Facade
+        pass
+
+
+class HandlerFacade:
+    def setFormatter(self, _):
+        pass
+
+
+logger = logging.getLogger("android_notify") if not on_flet_app() else AndroidNotifyLogger()
+
+# if not on flet android app use regular logger
+handler = logging.StreamHandler(sys.stdout) if not on_flet_app() else HandlerFacade()
 formatter = KivyColorFormatter()
+
 handler.setFormatter(formatter)
 # handler.setLevel(logging.WARNING) # this override app logger level
 
@@ -38,18 +152,14 @@ logger.propagate = False
 logger.addHandler(handler)
 logger._configured = True
 
-
-
 env_level = os.getenv("ANDROID_NOTIFY_LOGLEVEL")
 if env_level:
     # noinspection PyBroadException
     try:
-        logging.getLogger("android_notify").setLevel( getattr(logging, env_level.upper()) )
+        logger.setLevel(getattr(logging, env_level.upper()))
     except Exception as android_notify_loglevel_error:
-        print("android_notify_loglevel_error:",android_notify_loglevel_error)
+        android_print(f"android_notify_loglevel_error: {android_notify_loglevel_error}")
         pass
-
-
 
 if __name__ == "__main__":
     from kivymd.app import MDApp


### PR DESCRIPTION
This Allows Logs to be visible on Flet Android Apps when Complied.

run `adb logcat | grep python` to see all logs.

Also users can use `android_print` to print to terminal when complied or not
```python
from android_notify import Notification
from android_notify.internal.logger import android_print

android_print("successful imported android_notify...")
```