### PR TITLE
Make Custom sound through absolute file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ n.send()
 <details>
 <summary> <b>To use Custom Sounds </b> </summary>
 
+**Option 1: Audio files bundled in `res/raw`**
+
 - Put audio files in `res/raw` folder,
 - Then from `buildozer.spec` point to res folder `android.add_resources = res`
 - and includes it's format `source.include_exts = wav`.
@@ -209,6 +211,37 @@ n=Notification(
 n.setSound("sneeze")# for android 7 below 
 n.send()
 ```
+
+**Option 2: Local file path or URI (`sound_path`)**
+
+You can use a local audio file, a `content://`, `file://`, or `android.resource://` URI directly:
+
+```py
+# Using a local file path
+Notification.createChannel(
+    id="local_sound",
+    name="Local Sound",
+    sound_path="/storage/emulated/0/Download/alert.mp3"
+)
+
+# Using a content URI (e.g., from media store)
+Notification.createChannel(
+    id="uri_sound",
+    name="URI Sound",
+    sound_path="content://media/external/audio/media/123"
+)
+
+# Send notification with custom sound path
+n = Notification(
+    title="Custom Sound",
+    message="Playing from local path",
+    channel_id="local_sound"
+)
+n.setSound(sound_path="/storage/emulated/0/Download/alert.mp3")
+n.send()
+```
+
+Private files (e.g., in app's `data/` directory) are automatically copied to external storage before playing.
 </details>
 
 

--- a/android_notify/internal/android.py
+++ b/android_notify/internal/android.py
@@ -1,14 +1,14 @@
 """
 Android related logic
 """
-import time
+import time, os
 
 from .logger import logger
 from ..config import get_notification_manager, on_android_platform, from_service_file, on_flet_app, \
     get_python_activity_context
 from .permissions import has_notification_permission
 from .java_classes import autoclass, BuildVersion, Uri, NotificationCompat, NotificationManagerCompat, \
-    NotificationManager, Context
+    NotificationManager, Context, File
 from .an_types import Importance
 
 
@@ -98,22 +98,72 @@ def get_sound_uri(res_sound_name):
     return Uri.parse(f"android.resource://{package_name}/raw/{res_sound_name}")
 
 
-def set_sound(builder, res_sound_name):
+def get_sound_uri_from_path(sound_path):
+    if not on_android_platform() or not sound_path:
+        return None
+
+    if sound_path.startswith("content://") or sound_path.startswith("file://") or sound_path.startswith("android.resource://"):
+        try:
+            return Uri.parse(sound_path)
+        except Exception as e:
+            logger.exception(f"Error parsing sound URI: {sound_path}")
+            return None
+
+    # Resolve relative paths
+    abs_path = os.path.abspath(sound_path)
+    if not os.path.exists(abs_path):
+        logger.warning(f"Sound file does not exist: {sound_path} (resolved to {abs_path})")
+        return None
+
+    # Check if the file is in private storage (contains /data/)
+    if "/data/" in abs_path or not (abs_path.startswith("/storage") or abs_path.startswith("/sdcard")):
+        try:
+            context = get_python_activity_context()
+            ext_files = context.getExternalFilesDir("Notifications")
+            if ext_files:
+                ext_files_path = ext_files.getAbsolutePath()
+                dest_file = os.path.join(ext_files_path, os.path.basename(abs_path))
+
+                # Copy if destination doesn't exist or is older than the source
+                if not os.path.exists(dest_file) or os.path.getmtime(abs_path) > os.path.getmtime(dest_file):
+                    import shutil
+                    shutil.copy2(abs_path, dest_file)
+                abs_path = dest_file
+        except Exception as copy_error:
+            logger.exception(f"Failed to copy private sound file {abs_path} to external files: {copy_error}")
+
+    try:
+        java_file = File(abs_path)
+        return Uri.fromFile(java_file)
+    except Exception as e:
+        logger.exception(f"Error generating Uri from file path: {abs_path}")
+        return None
+
+
+def set_sound(builder, res_sound_name=None, sound_path=None):
     """
     Sets sound for devices less than android 8 (For 8+ use createChannel)
     :param builder: builder instance
     :param res_sound_name: audio file name (without .wav or .mp3) locate in res/raw/
+    :param sound_path: local file path or uri string
     """
 
     if not on_android_platform():
         return None
 
-    if res_sound_name and BuildVersion.SDK_INT < 26:
-        try:
-            builder.setSound(get_sound_uri(res_sound_name))
-            return True
-        except Exception as failed_adding_sound_for_devices_below_android8:
-            logger.exception(failed_adding_sound_for_devices_below_android8)
+    if BuildVersion.SDK_INT < 26:
+        sound_uri = None
+        if sound_path:
+            sound_uri = get_sound_uri_from_path(sound_path)
+        elif res_sound_name:
+            sound_uri = get_sound_uri(res_sound_name)
+
+        if sound_uri:
+            try:
+                builder.setSound(sound_uri)
+                return True
+            except Exception as failed_adding_sound_for_devices_below_android8:
+                logger.exception(failed_adding_sound_for_devices_below_android8)
     return None
 
 

--- a/android_notify/internal/channels.py
+++ b/android_notify/internal/channels.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from android_notify.config import get_notification_manager, on_android_platform
 
-from android_notify.internal.java_classes import BuildVersion, NotificationChannel
+from android_notify.internal.java_classes import BuildVersion, NotificationChannel, AudioAttributes, AudioAttributesBuilder
 from android_notify.internal.an_types import Importance
-from android_notify.internal.android import get_sound_uri, get_android_importance
+from android_notify.internal.android import get_sound_uri, get_sound_uri_from_path, get_android_importance
 from android_notify.internal.logger import logger
 
 def does_channel_exist(channel_id):
@@ -24,7 +24,7 @@ def does_channel_exist(channel_id):
     return False
 
 
-def create_channel(id__, name: str, description='', importance: Importance = 'urgent', res_sound_name=None,vibrate=False):
+def create_channel(id__, name: str, description='', importance: Importance = 'urgent', res_sound_name=None, sound_path=None, vibrate=False):
     """
     Creates a user visible toggle button for specific notifications, Required For Android 8.0+
     :param id__: Used to send other notifications later through same channel.
@@ -32,12 +32,13 @@ def create_channel(id__, name: str, description='', importance: Importance = 'ur
     :param description: user-visible detail about channel (Not required defaults to empty str).
     :param importance: ['urgent', 'high', 'medium', 'low', 'none'] defaults to 'urgent' i.e. makes a sound and shows briefly
     :param res_sound_name: audio file name (without .wav or .mp3) locate in res/raw/
+    :param sound_path: local file path or uri string
     :param vibrate: if channel notifications should vibrate or not
     :return: boolean if channel created
     """
     def info_log():
         logger.info(
-            f"Created {name} channel, id: {id__}, description: {description}, res_sound_name: {res_sound_name},vibrate: {vibrate}")
+            f"Created {name} channel, id: {id__}, description: {description}, res_sound_name: {res_sound_name}, sound_path: {sound_path}, vibrate: {vibrate}")
 
     if not on_android_platform():
         info_log()
@@ -45,14 +46,26 @@ def create_channel(id__, name: str, description='', importance: Importance = 'ur
 
     notification_manager = get_notification_manager()
     android_importance_value = get_android_importance(importance)
-    sound_uri = get_sound_uri(res_sound_name)
+    
+    if sound_path:
+        sound_uri = get_sound_uri_from_path(sound_path)
+    else:
+        sound_uri = get_sound_uri(res_sound_name)
 
     if not does_channel_exist(id__):
         channel = NotificationChannel(id__, name, android_importance_value)
         if description:
             channel.setDescription(description)
         if sound_uri:
-            channel.setSound(sound_uri, None)
+            try:
+                aa_builder = AudioAttributesBuilder()
+                aa_builder.setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                aa_builder.setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                audio_attributes = aa_builder.build()
+                channel.setSound(sound_uri, audio_attributes)
+            except Exception as sound_attributes_error:
+                logger.warning(f"Could not build AudioAttributes, falling back to None: {sound_attributes_error}")
+                channel.setSound(sound_uri, None)
         if vibrate:
             # channel.setVibrationPattern([0, 500, 200, 500]) # Using Phone's default pattern
             # Android 15 ignored long patterns, didn't vibrate when not in silent and

--- a/android_notify/internal/facade.py
+++ b/android_notify/internal/facade.py
@@ -106,6 +106,49 @@ class Uri:
     def __init__(self, package_name):
         logger.debug("FACADE_URI")
 
+    @classmethod
+    def parse(cls, uri_string):
+        logger.debug(f"[MOCK] Uri.parse called with uri_string={uri_string}")
+        return cls
+
+    @classmethod
+    def fromFile(cls, java_file):
+        logger.debug(f"[MOCK] Uri.fromFile called with file={java_file}")
+        return cls
+
+
+class AudioAttributes:
+    CONTENT_TYPE_SONIFICATION = 4
+    USAGE_NOTIFICATION = 5
+    USAGE_ALARM = 4
+
+
+class AudioAttributesBuilder:
+    def __init__(self):
+        logger.debug("[MOCK] AudioAttributesBuilder initialized")
+
+    def setContentType(self, content_type):
+        logger.debug(f"[MOCK] AudioAttributesBuilder.setContentType called with content_type={content_type}")
+        return self
+
+    def setUsage(self, usage):
+        logger.debug(f"[MOCK] AudioAttributesBuilder.setUsage called with usage={usage}")
+        return self
+
+    def build(self):
+        logger.debug("[MOCK] AudioAttributesBuilder.build called")
+        return AudioAttributes()
+
+
+class File:
+    def __init__(self, path):
+        self.path = path
+        logger.debug(f"[MOCK] File initialized with path={path}")
+
+    def getAbsolutePath(self):
+        logger.debug(f"[MOCK] File.getAbsolutePath called, returning {self.path}")
+        return self.path
+
 
 class NotificationManager:
     pass
@@ -401,6 +444,16 @@ class Context:
     def getPackageName():
         logger.debug("[MOCK] Context.getPackageName called")
         return None  # TODO get package name from buildozer.spec file
+
+    @staticmethod
+    def getExternalFilesDir(directory_type):
+        logger.debug(f"[MOCK] Context.getExternalFilesDir called with type={directory_type}")
+        return File("mock_external_files_dir")
+
+    @staticmethod
+    def getExternalCacheDir():
+        logger.debug("[MOCK] Context.getExternalCacheDir called")
+        return File("mock_external_cache_dir")
 
 
 class PackageManager:

--- a/android_notify/internal/java_classes.py
+++ b/android_notify/internal/java_classes.py
@@ -40,6 +40,9 @@ if on_android_platform():
         Color = autoclass('android.graphics.Color')
         Context = autoclass('android.content.Context')
         PackageManager = autoclass("android.content.pm.PackageManager")
+        AudioAttributes = autoclass('android.media.AudioAttributes')
+        AudioAttributesBuilder = autoclass('android.media.AudioAttributes$Builder')
+        File = autoclass('java.io.File')
     except Exception as e:
         from .facade import *
         logger.exception("Didn't get Basic Java Classes")

--- a/android_notify/sword.py
+++ b/android_notify/sword.py
@@ -149,7 +149,7 @@ class Notification(BaseNotification):
         return does_channel_exist(channel_id=channel_id)
 
     @classmethod
-    def createChannel(cls, id, name: str, description='', importance: Importance = 'urgent', res_sound_name=None, vibrate=False):
+    def createChannel(cls, id, name: str, description='', importance: Importance = 'urgent', res_sound_name=None, sound_path=None, vibrate=False):
         """
         Creates a user visible toggle button for specific notifications, Required For Android 8.0+
         :param id: Used to send other notifications later through same channel.
@@ -157,10 +157,11 @@ class Notification(BaseNotification):
         :param description: user-visible detail about channel (Not required defaults to empty str).
         :param importance: ['urgent', 'high', 'medium', 'low', 'none'] defaults to 'urgent' i.e. makes a sound and shows briefly
         :param res_sound_name: audio file name (without .wav or .mp3) locate in res/raw/
+        :param sound_path: local file path or uri string
         :param vibrate: if channel notifications should vibrate or not
         :return: boolean if channel created
         """
-        return create_channel(id__=id, name=name, description=description, importance=importance, res_sound_name=res_sound_name, vibrate=vibrate)
+        return create_channel(id__=id, name=name, description=description, importance=importance, res_sound_name=res_sound_name, sound_path=sound_path, vibrate=vibrate)
 
     @classmethod
     def deleteChannel(cls, channel_id):
@@ -558,13 +559,14 @@ class Notification(BaseNotification):
         """Pass in a list of strings to be used for lines"""
         set_lines(builder=self.builder, lines=lines)
 
-    def setSound(self, res_sound_name):
+    def setSound(self, res_sound_name=None, sound_path=None):
         """
         Sets sound for devices less than android 8 (For 8+ use createChannel)
         :param res_sound_name: audio file name (without .wav or .mp3) locate in res/raw/
+        :param sound_path: local file path or uri string
         """
 
-        return set_sound(self.builder, res_sound_name)
+        return set_sound(self.builder, res_sound_name=res_sound_name, sound_path=sound_path)
 
     def fill_args(self, silent: bool = False, persistent=False, close_on_click=True):
         """Name Makes More sense than start_building

--- a/android_notify/tests/test_notification_sound.py
+++ b/android_notify/tests/test_notification_sound.py
@@ -22,3 +22,46 @@ class TestNotificationSound(AndroidNotifyBaseTest):
             n.send()
         except Exception as e:
             self.fail(f"Sound failed: {e}")
+
+    def test_set_sound_path(self):
+        import os
+        mock_file = "test_mock_sound.mp3"
+        with open(mock_file, "w") as f:
+            f.write("mock audio data")
+
+        try:
+            Notification.createChannel(
+                id="sound_path_test",
+                name="Sound Path Test",
+                sound_path=mock_file
+            )
+            n = Notification(
+                title="Sound Path Test",
+                message="Testing custom sound path",
+                channel_id="sound_path_test"
+            )
+            n.setSound(sound_path=mock_file)
+            n.send()
+        except Exception as e:
+            self.fail(f"Sound path failed: {e}")
+        finally:
+            if os.path.exists(mock_file):
+                os.remove(mock_file)
+
+    def test_set_sound_content_uri(self):
+        try:
+            content_uri = "content://media/external/audio/media/123"
+            Notification.createChannel(
+                id="sound_uri_test",
+                name="Sound Uri Test",
+                sound_path=content_uri
+            )
+            n = Notification(
+                title="Sound Uri Test",
+                message="Testing content URI",
+                channel_id="sound_uri_test"
+            )
+            n.setSound(sound_path=content_uri)
+            n.send()
+        except Exception as e:
+            self.fail(f"Sound content URI failed: {e}")


### PR DESCRIPTION
Passed Test on pydroid 3
Install through `https://github.com/Fector101/android_notify/archive/without-androidx-custom-sound.zip`

`sound_path` accepts:
-  `Absolute path`: e.g- `/storage/emulated/0/Download/custom_sound.mp3`
- `Relative path`: e.g- `assets/sound.wav` Resolve to an absolute path in the Python environment
- `Android content URIs`: e.g, -`content://com.android.providers.media.documents/document/audio%3A12345`, If the path starts with `content://` or `file://` or `android.resource://` this allows seamless integration with file/audio pickers.

If the user provides a path to a file on public storage `(like /storage/emulated/0/...)` the app will require storage permissions:
`READ_EXTERNAL_STORAGE` on Android 12 and below.
`READ_MEDIA_AUDIO` on Android 13+.


```python
from kivy.app import App
from kivy.uix.button import Button
from android_notify import Notification

wav_file_path="/storage/emulated/0/sneeze.wav"

class AndroidNotifyDemoApp(App):
    def build(self):
        return Button(
            text="Send Notification",
            on_release=self.send_notification
        )

    def send_notification(self, *args):
        Notification.createChannel(
            id="game",
            name="Game Sound Tester",
            description="A custom sounds from the phone folder.",
            sound_path=wav_file_path
        )
        n=Notification(
            title="Hello from Android Notify",
            message="This is a basic notification.",
            channel_id="game",
        )
        n.setSound(sound_path=wav_file_path)
        n.send()


if __name__ == "__main__":
    AndroidNotifyDemoApp().run()
```